### PR TITLE
Fix Dialog

### DIFF
--- a/Assets/Scripts/Dialog/CHDialog.cs
+++ b/Assets/Scripts/Dialog/CHDialog.cs
@@ -9,18 +9,10 @@ public abstract class CHDialog: MonoBehaviour {
 
     private FirstPersonController _controller;
 
-    // Use this for initialization
-    private void Start () {
-        _tree = new DialogTree(CharacterName);
-    }
-
     protected void StartDialog(FirstPersonController controller) {
-        UpdateText();
+        _tree = new DialogTree(CharacterName);
         _controller = controller;
-
-        if (_controller == null) {
-            return;
-        }
+        UpdateText();
         
         _controller.enabled = false;
     }

--- a/Assets/Scripts/Dialog/RadiusDialog.cs
+++ b/Assets/Scripts/Dialog/RadiusDialog.cs
@@ -7,6 +7,11 @@ public class RadiusDialog: CHDialog {
 		if (!other.CompareTag("Player")) return;
 		var controller = other.GetComponent<FirstPersonController>();
 		
-		StartDialog(controller);
+		print(controller);
+		
+		// Why?
+		if (controller != null) {
+			StartDialog(controller);
+		}
 	}
 }


### PR DESCRIPTION
On recreation, the dialog would start at the end, causing the player not to be able to leave the dialog state.

Fixed by restarting dialog tree from scratch for each conversation. 

Also, unrelated was that the controller would be null half the time because somebody added the player tag to an object that didn't have a FPC on it. Fixed it by adding a check before creation. 